### PR TITLE
Reject callbacks on socket close with Error

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -247,13 +247,15 @@ class Chrome extends EventEmitter {
     }
 
     _handleConnectionClose() {
+        // make sure to complete all the unresolved callbacks
         const err = new Error('WebSocket connection closed');
         for (const callback of Object.values(this._callbacks)) {
-            callback(true, err);
+            callback(err);
         }
         this._callbacks = {};
         this._callbacks_start_ts = {};
     }
+
     // handle the messages read from the WebSocket
     _handleMessage(message) {
         // command response


### PR DESCRIPTION
Using true for first argument is expected for ProtocolError, which is not the case